### PR TITLE
add more rates, minimum ivs

### DIFF
--- a/common/src/main/java/com/kingpixel/wondertrade/Config/Config.java
+++ b/common/src/main/java/com/kingpixel/wondertrade/Config/Config.java
@@ -34,7 +34,14 @@ public class Config {
   private int maxlv;
   private boolean poolview;
   private int shinyrate;
+  private int mythicalrate;
+  private int mythicalperfectivs;
   private int legendaryrate;
+  private int legendaryperfectivs;
+  private int ultrabeastrate;
+  private int ultrabeastperfectivs;
+  private int paradoxrate;
+  private int paradoxperfectivs;
   private boolean israndom;
   private int cooldown;
   private Map<String, Integer> cooldownPermission;
@@ -60,7 +67,14 @@ public class Config {
     minlv = 5;
     maxlv = 36;
     shinyrate = 8192;
+    mythicalrate = 16512;
+    mythicalperfectivs = 3;
     legendaryrate = 16512;
+    legendaryperfectivs = 3;
+    ultrabeastrate = 512;
+    ultrabeastperfectivs = 2;
+    paradoxrate = 256;
+    paradoxperfectivs = 2;
     poolview = true;
     israndom = false;
     cooldownPermission = Map.of(

--- a/common/src/main/java/com/kingpixel/wondertrade/command/CommandTree.java
+++ b/common/src/main/java/com/kingpixel/wondertrade/command/CommandTree.java
@@ -182,7 +182,7 @@ public class CommandTree {
   }
 
   public static PokemonStats calculatePokemonStats(List<Pokemon> pokemons) {
-    int shinys = 0, legendaries = 0, ultraBeasts = 0, paradoxes = 0, ivs31 = 0;
+    int shinys = 0, legendaries = 0, mythicals = 0, ultraBeasts = 0, paradoxes = 0, ivs31 = 0;
     List<Pokemon> special = new ArrayList<>();
 
     for (Pokemon pokemon : pokemons) {
@@ -193,6 +193,10 @@ public class CommandTree {
       }
       if (pokemon.isLegendary()) {
         legendaries++;
+        isSpecial = true;
+      }
+      if (pokemon.isMythical()) {
+        mythicals++;
         isSpecial = true;
       }
       if (pokemon.isUltraBeast()) {
@@ -212,7 +216,7 @@ public class CommandTree {
       }
     }
 
-    return new PokemonStats(shinys, legendaries, ultraBeasts, paradoxes, ivs31, special, pokemons);
+    return new PokemonStats(shinys, legendaries, mythicals, ultraBeasts, paradoxes, ivs31, special, pokemons);
   }
 
   public static List<String> prepareLore(List<String> loreTemplate, PokemonStats stats, UserInfo userinfo) {
@@ -234,6 +238,7 @@ public class CommandTree {
     return s
       .replace("%shinys%", String.valueOf(stats.shinys))
       .replace("%legends%", String.valueOf(stats.legendaries))
+      .replace("%mythicals%", String.valueOf(stats.mythicals))
       .replace("%ultrabeast%", String.valueOf(stats.ultraBeasts))
       .replace("%paradox%", String.valueOf(stats.paradoxes))
       .replace("%ivs%", String.valueOf(stats.ivs31));
@@ -270,19 +275,55 @@ public class CommandTree {
       pokemonObtained = CobbleWonderTrade.config.getFilterGenerationPokemon().generateRandomPokemon(
         CobbleWonderTrade.MOD_ID,
         "pool");
+        
+      int paradox = -1, ultraBeast = -1, legendary = -1, mythical = -1, shiny = -1;
+      if (CobbleWonderTrade.config.getParadoxrate() > 0) {
+        paradox = Utils.RANDOM.nextInt(CobbleWonderTrade.config.getParadoxrate());
+        if (paradox == 0 && !pokemonObtained.getForm().getLabels().contains(CobblemonPokemonLabels.PARADOX)) {
+          pokemonObtained = DatabaseClientFactory.getParadox();
+          DatabaseClientFactory.applyPerfectIvs(pokemonObtained, CobbleWonderTrade.config.getParadoxperfectivs());
+        }
+      }
 
-      int legendary = Utils.RANDOM.nextInt(CobbleWonderTrade.config.getLegendaryrate());
-      int shiny = Utils.RANDOM.nextInt(CobbleWonderTrade.config.getShinyrate());
-      if (legendary == 0 && !pokemonObtained.getForm().getLabels().contains(CobblemonPokemonLabels.LEGENDARY)) {
-        pokemonObtained = DatabaseClientFactory.getLegendary();
+      if (CobbleWonderTrade.config.getUltrabeastrate() > 0) {
+        ultraBeast = Utils.RANDOM.nextInt(CobbleWonderTrade.config.getUltrabeastrate());
+        if (ultraBeast == 0 && !pokemonObtained.getForm().getLabels().contains(CobblemonPokemonLabels.ULTRA_BEAST)) {
+          pokemonObtained = DatabaseClientFactory.getUltraBeast();
+          DatabaseClientFactory.applyPerfectIvs(pokemonObtained, CobbleWonderTrade.config.getUltrabeastperfectivs());
+        }
       }
-      if (shiny == 0) {
-        pokemonObtained.setShiny(true);
+
+      if (CobbleWonderTrade.config.getLegendaryrate() > 0) {
+        legendary = Utils.RANDOM.nextInt(CobbleWonderTrade.config.getLegendaryrate());
+        if (legendary == 0 && !pokemonObtained.getForm().getLabels().contains(CobblemonPokemonLabels.LEGENDARY)) {
+          pokemonObtained = DatabaseClientFactory.getLegendary();
+          DatabaseClientFactory.applyPerfectIvs(pokemonObtained, CobbleWonderTrade.config.getLegendaryperfectivs());
+        }
       }
+
+      if (CobbleWonderTrade.config.getMythicalrate() > 0) {
+        mythical = Utils.RANDOM.nextInt(CobbleWonderTrade.config.getMythicalrate());
+        if (mythical == 0 && !pokemonObtained.getForm().getLabels().contains(CobblemonPokemonLabels.MYTHICAL)) {
+          pokemonObtained = DatabaseClientFactory.getMythical();
+          DatabaseClientFactory.applyPerfectIvs(pokemonObtained, CobbleWonderTrade.config.getMythicalperfectivs());
+        }
+      }
+
+      if (CobbleWonderTrade.config.getShinyrate() > 0) {
+        shiny = Utils.RANDOM.nextInt(CobbleWonderTrade.config.getShinyrate());
+        if (shiny == 0) {
+          pokemonObtained.setShiny(true);
+        }
+      }
+
       if (CobbleWonderTrade.config.isDebug()) {
+        CobbleUtils.LOGGER.info(CobbleWonderTrade.MOD_ID, "Paradox: " + paradox);
+        CobbleUtils.LOGGER.info(CobbleWonderTrade.MOD_ID, "Ultra Beast: " + ultraBeast);
         CobbleUtils.LOGGER.info(CobbleWonderTrade.MOD_ID, "Legendary: " + legendary);
+        CobbleUtils.LOGGER.info(CobbleWonderTrade.MOD_ID, "Mythical: " + mythical);
         CobbleUtils.LOGGER.info(CobbleWonderTrade.MOD_ID, "Shiny: " + shiny);
       }
+
       DatabaseClientFactory.setLevel(pokemonObtained);
     }
     updatePlayerStorage(player, pokemon, pokemonObtained);
@@ -380,14 +421,14 @@ public class CommandTree {
   // Clase auxiliar para estadísticas de Pokémon
   @Data
   public static class PokemonStats {
-    int shinys, legendaries, ultraBeasts, paradoxes, ivs31;
+    int shinys, legendaries, mythicals, ultraBeasts, paradoxes, ivs31;
     private List<Pokemon> special;
     private List<Pokemon> pokemons;
 
-    public PokemonStats(int shinys, int legendaries, int ultraBeasts, int paradoxes, int ivs31, List<Pokemon> special
-      , List<Pokemon> pokemons) {
+    public PokemonStats(int shinys, int legendaries, int mythicals, int ultraBeasts, int paradoxes, int ivs31, List<Pokemon> special, List<Pokemon> pokemons) {
       this.shinys = shinys;
       this.legendaries = legendaries;
+      this.mythicals = mythicals;
       this.ultraBeasts = ultraBeasts;
       this.paradoxes = paradoxes;
       this.ivs31 = ivs31;

--- a/common/src/main/java/com/kingpixel/wondertrade/database/DatabaseClientFactory.java
+++ b/common/src/main/java/com/kingpixel/wondertrade/database/DatabaseClientFactory.java
@@ -1,8 +1,10 @@
 package com.kingpixel.wondertrade.database;
 
 import com.cobblemon.mod.common.Cobblemon;
+import com.cobblemon.mod.common.api.pokemon.PokemonProperties;
 import com.cobblemon.mod.common.api.pokemon.PokemonSpecies;
 import com.cobblemon.mod.common.api.pokemon.labels.CobblemonPokemonLabels;
+import com.cobblemon.mod.common.api.pokemon.stats.Stats;
 import com.cobblemon.mod.common.pokemon.Pokemon;
 import com.cobblemon.mod.common.pokemon.Species;
 import com.kingpixel.cobbleutils.Model.DataBaseConfig;
@@ -58,16 +60,55 @@ public class DatabaseClientFactory {
     return pokemons;
   }
 
-
   private static void applyProperties(List<Pokemon> pokemons) {
     for (int i = 0; i < pokemons.size(); i++) {
       Pokemon pokemon = pokemons.get(i);
-      if (CobbleWonderTrade.config.getLegendaryrate() > 0) {
-        int legendary = Utils.RANDOM.nextInt(CobbleWonderTrade.config.getLegendaryrate());
-        if (legendary == 0 && !pokemon.getForm().getLabels().contains(CobblemonPokemonLabels.LEGENDARY)) {
-          pokemons.set(i, DatabaseClientFactory.getLegendary());
+      boolean replaced = false;
+
+      // Mythical rate
+      if (CobbleWonderTrade.config.getMythicalrate() > 0) {
+        int mythical = Utils.RANDOM.nextInt(CobbleWonderTrade.config.getMythicalrate());
+        if (mythical == 0 && !pokemon.isMythical()) {
+          Pokemon newPokemon = DatabaseClientFactory.getMythical();
+          applyPerfectIvs(newPokemon, CobbleWonderTrade.config.getMythicalperfectivs());
+          pokemons.set(i, newPokemon);
+          replaced = true;
         }
       }
+
+      // Legendary rate
+      if (!replaced && CobbleWonderTrade.config.getLegendaryrate() > 0) {
+        int legendary = Utils.RANDOM.nextInt(CobbleWonderTrade.config.getLegendaryrate());
+        if (legendary == 0 && !pokemon.isLegendary()) {
+          Pokemon newPokemon = DatabaseClientFactory.getLegendary();
+          applyPerfectIvs(newPokemon, CobbleWonderTrade.config.getLegendaryperfectivs());
+          pokemons.set(i, newPokemon);
+          replaced = true;
+        }
+      }
+
+      // Ultra Beast rate
+      if (!replaced && CobbleWonderTrade.config.getUltrabeastrate() > 0) {
+        int ultraBeast = Utils.RANDOM.nextInt(CobbleWonderTrade.config.getUltrabeastrate());
+        if (ultraBeast == 0 && !pokemon.isUltraBeast()) {
+          Pokemon newPokemon = DatabaseClientFactory.getUltraBeast();
+          applyPerfectIvs(newPokemon, CobbleWonderTrade.config.getUltrabeastperfectivs());
+          pokemons.set(i, newPokemon);
+          replaced = true;
+        }
+      }
+
+      // Paradox rate
+      if (!replaced && CobbleWonderTrade.config.getParadoxrate() > 0) {
+        int paradox = Utils.RANDOM.nextInt(CobbleWonderTrade.config.getParadoxrate());
+        if (paradox == 0 && !pokemon.getForm().getLabels().contains(CobblemonPokemonLabels.PARADOX)) {
+          Pokemon newPokemon = DatabaseClientFactory.getParadox();
+          applyPerfectIvs(newPokemon, CobbleWonderTrade.config.getParadoxperfectivs());
+          pokemons.set(i, newPokemon);
+        }
+      }
+
+      // Shiny rate
       if (CobbleWonderTrade.config.getShinyrate() > 0) {
         int shiny = Utils.RANDOM.nextInt(CobbleWonderTrade.config.getShinyrate());
         if (shiny == 0) {
@@ -77,15 +118,32 @@ public class DatabaseClientFactory {
     }
   }
 
+  public static void applyPerfectIvs(Pokemon pokemon, int count) {
+    if (count <= 0) return;
+    PokemonProperties.Companion.parse("min_perfect_ivs=" + count).apply(pokemon);
+  }
+
+  private static Pokemon getRandomByLabel(String label) {
+    List<Species> filtered = PokemonSpecies.getImplemented().stream()
+            .filter(s -> s.getLabels().contains(label))
+            .toList();
+    return filtered.get(Utils.RANDOM.nextInt(filtered.size())).create(1);
+  }
+
   public static Pokemon getLegendary() {
-    var species = PokemonSpecies.INSTANCE.getImplemented();
-    List<Species> legendaries = new ArrayList<>();
-    for (Species s : species) {
-      if (s.getLabels().contains(CobblemonPokemonLabels.LEGENDARY)) {
-        legendaries.add(s);
-      }
-    }
-    return legendaries.get(Utils.RANDOM.nextInt(legendaries.size())).create(1);
+    return getRandomByLabel(CobblemonPokemonLabels.LEGENDARY);
+  }
+
+  public static Pokemon getMythical() {
+    return getRandomByLabel(CobblemonPokemonLabels.MYTHICAL);
+  }
+
+  public static Pokemon getUltraBeast() {
+    return getRandomByLabel(CobblemonPokemonLabels.ULTRA_BEAST);
+  }
+
+  public static Pokemon getParadox() {
+    return getRandomByLabel(CobblemonPokemonLabels.PARADOX);
   }
 
   public static void putLevels(List<Pokemon> pokemons) {
@@ -93,7 +151,6 @@ public class DatabaseClientFactory {
       setLevel(pokemon);
     }
   }
-
 
   public static void setLevel(Pokemon pokemon) {
     pokemon.setLevel(Utils.RANDOM.nextInt(CobbleWonderTrade.config.getMinlv(), CobbleWonderTrade.config.getMaxlv() + 1));


### PR DESCRIPTION
allow %mythicals% placeholder in wondertrade lore
add mythicalrate, paradoxrate, and ultrabeastrate to control how frequently they appear
add mythicalperfectivs, legendaryperfectivs, ultrabeastperfectivs, and paradoxperfectivs to control minimum perfect ivs in the pool
should be backward compatible
